### PR TITLE
Use query parameter for video status polling

### DIFF
--- a/src/pages/Analysis.tsx
+++ b/src/pages/Analysis.tsx
@@ -179,12 +179,14 @@ const Analysis = () => {
   const pollVideoStatus = useCallback(async (videoId: string) => {
     const poll = async () => {
       try {
-        const { data, error } = await supabase.functions.invoke('get-video-status', {
-          body: { videoId },
-          headers: {
-            Authorization: `Bearer ${(await supabase.auth.getSession()).data.session?.access_token}`,
+        const { data, error } = await supabase.functions.invoke(
+          `get-video-status?videoId=${encodeURIComponent(videoId)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${(await supabase.auth.getSession()).data.session?.access_token}`,
+            }
           }
-        });
+        );
 
         if (error) throw error;
 


### PR DESCRIPTION
## Summary
- send video ID via query string when polling the `get-video-status` function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_68938ecd8884832b884c917b4e860228